### PR TITLE
Fix loot sheet

### DIFF
--- a/module/sheets/WitcherActorSheet.js
+++ b/module/sheets/WitcherActorSheet.js
@@ -73,13 +73,14 @@ export default class WitcherActorSheet extends ActorSheet {
     });
 
     // Crafting section
-    data.allComponents = actor.getList("component");
+    data.allComponents = actor.getList("component"); // used in Loot Sheet
     data.craftingMaterials = data.allComponents.filter(i => i.system.type == "crafting-material" || i.system.type == "component");
     data.ingotsAndMinerals = data.allComponents.filter(i => i.system.type == "minerals");
     data.hidesAndAnimalParts = data.allComponents.filter(i => i.system.type == "animal-parts");
     data.enhancements = items.filter(i => i.type == "enhancement" && i.system.type != "armor" && !i.system.applied);
 
     // Valuables Section
+    data.valuables = items.filter(i => i.type == "valuable"); // used in Loot Sheet
     data.clothingAndContainers = items.filter(i => i.type == "valuable" && (i.system.type == "clothing" || i.system.type == "containers"));
     data.general = items.filter(i => i.type == "valuable" && (i.system.type == "genera" || !i.system.type));
     data.foodAndDrinks = items.filter(i => i.type == "valuable" && i.system.type == "food-drink");
@@ -102,6 +103,7 @@ export default class WitcherActorSheet extends ActorSheet {
     data.oilDiagrams = actor.getList("diagrams").filter(d => d.system.type == "oil").map(sanitizeDescription);
     
     // Diagrams
+    data.diagrams = actor.getList("diagrams"); // used in Loot Sheet
     data.ingredientDiagrams = actor.getList("diagrams").filter(d => d.system.type == "ingredients").map(sanitizeDescription);
     data.weaponDiagrams = actor.getList("diagrams").filter(d => d.system.type == "weapon").map(sanitizeDescription);
     data.armorDiagrams = actor.getList("diagrams").filter(d => d.system.type == "armor").map(sanitizeDescription);

--- a/styles/item-sheets.css
+++ b/styles/item-sheets.css
@@ -142,6 +142,11 @@
     padding: 0.25em 0.25em;
 }
 
+.item-table td.center {
+    display: flex;
+    justify-content: center;
+}
+
 .spell-template-damage {
     width: 15em;
     margin-top: 0.6em;

--- a/styles/loot-sheet.css
+++ b/styles/loot-sheet.css
@@ -10,8 +10,34 @@
     border-width: 0px;
 }
 
-.item-section{
-    flex: 1
+.item-section {
+    flex: 1;
+    padding-left: 5px;
+}
+
+.item-section h3 {
+    margin: 0;
+    border: none;
+}
+
+.item-section table {
+    margin-top: 0;
+}
+
+.item-section .currencies {
+    display: flex;
+    height: 75px;
+}
+
+.item-section .currencies .currency {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+table tr.loot-sheet-table-header {
+    display: grid;
+    grid-template-columns: 49fr 78fr 61fr 211fr 211fr 211fr 109fr; /* These are the columns width on a specific dialog width, but with 'fr' instead of 'px' to make it relative/responsive. */
 }
 
 table tr.hidden-view {
@@ -19,7 +45,7 @@ table tr.hidden-view {
 }
 
 .hidden-from-view {
-    display: none
+    display: none;
 }
 
 .table-empty-space {

--- a/styles/system-styles.css
+++ b/styles/system-styles.css
@@ -189,6 +189,10 @@ input.item-quantity {
   flex: 1;
 }
 
+.weapon-section > .flex {
+  margin-bottom: 8px;
+}
+
 .weapon-section .flex label {
   margin-right: 5px;
   margin-bottom: 5px;
@@ -438,6 +442,7 @@ input.skill-value {
 }
 
 .item-img {
+  display: flex;
   border: none;
   width: 40px;
   height: 40px;

--- a/styles/tab-inventory.css
+++ b/styles/tab-inventory.css
@@ -16,7 +16,7 @@ table th {
 }
 
 .no-margin {
-    margin: 0px;;
+    margin: 0px;
 }
 
 .currency {
@@ -45,7 +45,7 @@ table th {
     position: relative;
     display: flex;
     cursor: pointer;
-    height: 44px;
+    height: 40px;
 }
 
 .item-img-wrapper .item-show {

--- a/templates/partials/loot-item-display.html
+++ b/templates/partials/loot-item-display.html
@@ -8,7 +8,9 @@
     <tr class="item" data-item-id="{{item._id}}">
 {{/if}}
     <td><a class="item-edit"><i class="fas fa-edit"></i></a></td>
-    <td><img src="{{item.img}}" class="item-img dragable" draggable="true" data-id="{{item._id}}"/></td>
+    <td class="center">
+        {{> "systems/TheWitcherTRPG/templates/partials/item-image.html" item=item}}
+    </td>
     <td><input class="inline-edit item-quantity" data-field="system.quantity" type="text"
                value="{{item.system.quantity}}" data-dtype="Number"/></td>
     <td><input class="inline-edit" data-field="name" type="text" value="{{item.name}}" placeholder="name"/></td>

--- a/templates/sheets/actor/loot-sheet.html
+++ b/templates/sheets/actor/loot-sheet.html
@@ -35,7 +35,7 @@
         </div>
     </div>
     <div class="item-section">
-        <div class="flex">
+        <div class="currencies">
             <div class="currency">
                 <label>{{localize "WITCHER.Currency.bizant"}}</label>
                 <input class="small-medium"
@@ -100,45 +100,49 @@
                        data-dtype="Number"/>
             </div>
         </div>
-        <h2>{{localize "WITCHER.Loot.Weapons"}} <a class="add-item" data-itemType="weapon"><i
-                class="fas fa-plus"></i></a></h2>
         <table class="item-table item-list">
-            <tr>
-                <td class="table-empty-space"></td>
-                <td></td>
-                <td><b>{{localize "WITCHER.table.Quantity"}}</b></td>
-                <td><b>{{localize "WITCHER.table.Name"}}</b></td>
-                <td><b>{{localize "WITCHER.Item.Weight"}}</b></td>
-                <td><b>{{localize "WITCHER.Item.Cost"}}</b></td>
-                <td class="table-empty-end-space"></td>
-            </tr>
+            <tbody>
+                <tr class="loot-sheet-table-header">
+                    <td></td>
+                    <td></td>
+                    <td><b>{{localize "WITCHER.table.Quantity"}}</b></td>
+                    <td><b>{{localize "WITCHER.table.Name"}}</b></td>
+                    <td><b>{{localize "WITCHER.Item.Weight"}}</b></td>
+                    <td><b>{{localize "WITCHER.Item.Cost"}}</b></td>
+                    <td></td>
+                </tr>
+            </tbody>
+        </table>
+        <h3>{{localize "WITCHER.Loot.Weapons"}} <a class="add-item" data-itemType="weapon"><i
+                class="fas fa-plus"></i></a></h3>
+        <table class="item-table item-list">
             {{#each weapons as |item id|}}
                 {{> "systems/TheWitcherTRPG/templates/partials/loot-item-display.html" item=item isGM=../isGM}}
             {{/each}}
         </table>
-        <h2>{{localize "WITCHER.Loot.Armors"}} <a class="add-item" data-itemType="armor"><i class="fas fa-plus"></i></a>
-        </h2>
+        <h3>{{localize "WITCHER.Loot.Armors"}} <a class="add-item" data-itemType="armor"><i class="fas fa-plus"></i></a>
+        </h3>
         <table class="item-table item-list">
             {{#each armors as |item id|}}
                 {{> "systems/TheWitcherTRPG/templates/partials/loot-item-display.html" item=item isGM=../isGM}}
             {{/each}}
         </table>
-        <h2>{{localize "WITCHER.Loot.Valuables"}} <a class="add-item" data-itemType="valuable"><i
-                class="fas fa-plus"></i></a></h2>
+        <h3>{{localize "WITCHER.Loot.Valuables"}} <a class="add-item" data-itemType="valuable"><i
+                class="fas fa-plus"></i></a></h3>
         <table class="item-table item-list">
             {{#each valuables as |item id|}}
                 {{> "systems/TheWitcherTRPG/templates/partials/loot-item-display.html" item=item isGM=../isGM}}
             {{/each}}
         </table>
-        <h2>{{localize "WITCHER.Loot.Diagrams"}} <a class="add-item" data-itemType="diagrams"><i
-                class="fas fa-plus"></i></a></h2>
+        <h3>{{localize "WITCHER.Loot.Diagrams"}} <a class="add-item" data-itemType="diagrams"><i
+                class="fas fa-plus"></i></a></h3>
         <table class="item-table item-list">
             {{#each diagrams as |item id|}}
                 {{> "systems/TheWitcherTRPG/templates/partials/loot-item-display.html" item=item isGM=../isGM}}
             {{/each}}
         </table>
-        <h2>{{localize "WITCHER.Loot.Components"}} <a class="add-item" data-itemType="component"><i
-                class="fas fa-plus"></i></a></h2>
+        <h3>{{localize "WITCHER.Loot.Components"}} <a class="add-item" data-itemType="component"><i
+                class="fas fa-plus"></i></a></h3>
         <table class="item-table item-list">
             {{#each allComponents as |item id|}}
                 {{> "systems/TheWitcherTRPG/templates/partials/loot-item-display.html" item=item isGM=../isGM}}


### PR DESCRIPTION
- valuables and diagrams are now shown
- improved UI for a cleaner look, and aligned table headers with columns
- loot sheet now supports zoomable items/images

![chest-empty](https://github.com/ortegamarcel/TheWitcherTRPG/assets/9929801/1b1bedd1-3771-47cd-81c4-344208ae5857)
![chest-full](https://github.com/ortegamarcel/TheWitcherTRPG/assets/9929801/c4c25b0f-9310-4f95-b3c9-8ccffcdb54a1)
![chest-zoomable](https://github.com/ortegamarcel/TheWitcherTRPG/assets/9929801/b8c2414c-d066-4286-8bd5-a50dd611a9cb)
